### PR TITLE
Add schemas to versions

### DIFF
--- a/deploy/crds/sysdig_v1_sysdig_crd.yaml
+++ b/deploy/crds/sysdig_v1_sysdig_crd.yaml
@@ -1,7 +1,6 @@
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
-  creationTimestamp: null
   name: sysdigagents.sysdig.com
 spec:
   group: sysdig.com
@@ -20,8 +19,16 @@ spec:
   version: v1
   versions:
   - name: v1
+    schema:
+      openAPIV3Schema:
+        type: object
+        x-kubernetes-preserve-unknown-fields: true
     served: true
     storage: true
   - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        type: object
+        x-kubernetes-preserve-unknown-fields: true
     served: false
     storage: false


### PR DESCRIPTION
Add schema definition to v1 and v1alpha1, otherwise in OCP 4.4 we receive an error like:

spec.versions[0].schema.openAPIV3Schema: Required value: schemas are required
spec.versions[1].schema.openAPIV3Schema: Required value: schemas are required