### PR TITLE
Revert wrong changes from previous PR

### DIFF
--- a/deploy/crds/sysdig_v1_sysdig_crd.yaml
+++ b/deploy/crds/sysdig_v1_sysdig_crd.yaml
@@ -19,16 +19,8 @@ spec:
   version: v1
   versions:
   - name: v1
-    schema:
-      openAPIV3Schema:
-        type: object
-        x-kubernetes-preserve-unknown-fields: true
     served: true
     storage: true
   - name: v1alpha1
-    schema:
-      openAPIV3Schema:
-        type: object
-        x-kubernetes-preserve-unknown-fields: true
     served: false
     storage: false


### PR DESCRIPTION
There was a confusion in my previous PR, and these changes shouldn't be applied to this CRD, as in v1beta1 there is an error if all versions have the same schema, and x-kubernetes-preserve-unkown-fields is not supported.