### PR TITLE
Make initialDelaySeconds configurable in sysdig-agent daemonset.

### DIFF
--- a/helm-charts/sysdig/README.md
+++ b/helm-charts/sysdig/README.md
@@ -63,6 +63,7 @@ The following table lists the configurable parameters of the Sysdig chart and th
 | `daemonset.nodeSelector`                          | Node Selector                                                                            | `{}`                                        |
 | `daemonset.affinity`                              | Node affinities                                                                          | `schedule on amd64 and linux`               |
 | `daemonset.annotations`                           | Custom annotations for daemonset                                                         | `{}`                                        |
+| `daemonset.livenessProbe.initialDelay`            | Initial delay before the liveness probe for sysdig-agent kicks in.                       | `10`                                        |
 | `slim.enabled`                                    | Use the slim based Sysdig Agent image                                                    | `false`                                     |
 | `slim.kmoduleImage.repository`                    | The kernel module image builder repository to pull from                                  | `sysdig/agent-kmodule`                      |
 | `slim.resources.requests.cpu`                     | CPU requested for building the kernel module                                             | `1000m`                                     |

--- a/helm-charts/sysdig/templates/daemonset.yaml
+++ b/helm-charts/sysdig/templates/daemonset.yaml
@@ -125,7 +125,7 @@ spec:
           livenessProbe:
             exec:
               command: [ "test", "-e", "/opt/draios/logs/running" ]
-            initialDelaySeconds: 10
+            initialDelaySeconds: {{ .Values.daemonset.livenessProbe.initialDelay }}
           volumeMounts:
             {{- if not .Values.slim.enabled }}
             - mountPath: /etc/modprobe.d

--- a/helm-charts/sysdig/values.yaml
+++ b/helm-charts/sysdig/values.yaml
@@ -60,6 +60,8 @@ daemonset:
   ## Extra environment variables that will be pass onto deployment pods
   env: {}
   nodeSelector: {}
+  livenessProbe:
+    initialDelay: 10
   # Allow the DaemonSet to schedule using affinity rules
   # Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
   affinity:


### PR DESCRIPTION
When `thin_cointerface` is enabled the initialDelaySeconds on livenessProbe is too small and it causes the agents to continuously restart without ever becoming ready.

That issue was also observed with a newer agent version `11.1.2`