### PR TITLE
Update kube-rbac-proxy image registry

### DIFF
--- a/bundle/manifests/sysdig-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/sysdig-operator.clusterserviceversion.yaml
@@ -221,10 +221,10 @@ spec:
                 resources:
                   limits:
                     cpu: 200m
-                    memory: 100Mi
+                    memory: 1000Mi
                   requests:
                     cpu: 100m
-                    memory: 60Mi
+                    memory: 300Mi
                 securityContext:
                   allowPrivilegeEscalation: false
               - args:

--- a/bundle/manifests/sysdig-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/sysdig-operator.clusterserviceversion.yaml
@@ -232,7 +232,7 @@ spec:
                 - --upstream=http://127.0.0.1:8080/
                 - --logtostderr=true
                 - --v=10
-                image: gcr.io/kubebuilder/kube-rbac-proxy:v0.8.0
+                image: registry.redhat.io/openshift4/ose-kube-rbac-proxy:v4.9.0
                 name: kube-rbac-proxy
                 ports:
                 - containerPort: 8443

--- a/config/default/manager_auth_proxy_patch.yaml
+++ b/config/default/manager_auth_proxy_patch.yaml
@@ -10,7 +10,7 @@ spec:
     spec:
       containers:
       - name: kube-rbac-proxy
-        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.8.0
+        image: registry.redhat.io/openshift4/ose-kube-rbac-proxy:v4.9.0
         args:
         - "--secure-listen-address=0.0.0.0:8443"
         - "--upstream=http://127.0.0.1:8080/"

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -47,9 +47,9 @@ spec:
         resources:
           limits:
             cpu: 200m
-            memory: 100Mi
+            memory: 1000Mi
           requests:
             cpu: 100m
-            memory: 60Mi
+            memory: 300Mi
       serviceAccountName: controller-manager
       terminationGracePeriodSeconds: 10


### PR DESCRIPTION
https://sysdig.atlassian.net/browse/SSPROD-10236

This changes the `kube-rbac-proxy` image from gcr.io to `openshift4/ose-kube-rbac-proxy` from the redhat registry.

Also raises the mem requests to `300Mi`, and limit to `1Gi`, which should be plenty of room.