### PR TITLE
Update resources to match desired bundle

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ IMAGE_TAG_BASE ?= sysdig-operator
 BUNDLE_IMG ?= $(IMAGE_TAG_BASE)-bundle:v$(VERSION)
 
 # Image URL to use all building/pushing image targets
-IMG ?= scan.connect.redhat.com/ospid-2953a149-0b38-4515-9768-dd548c234edb/sysdig-operator:$(VERSION)
+IMG ?= registry.connect.redhat.com/sysdig/sysdig-operator:$(VERSION)
 
 all: docker-build
 

--- a/bundle/manifests/sysdig-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/sysdig-operator.clusterserviceversion.yaml
@@ -12,7 +12,7 @@ metadata:
           },
           "spec": {
             "sysdig": {
-              "accessKey": "",
+              "accessKey": "REPLACE ME",
               "disableCaptures": false,
               "existingAccessKeySecret": "",
               "settings": {}
@@ -44,25 +44,23 @@ spec:
     owned:
     - kind: SysdigAgent
       name: sysdigagents.sysdig.com
-      version: v1
       resources:
       - kind: Service
-        name: ''
+        name: ""
         version: v1
       - kind: DaemonSet
-        name: ''
+        name: ""
         version: v1
       specDescriptors:
-      - description: ''
-        displayName: Tolerations
+      - displayName: Tolerations
         path: tolerations
-      - description: ''
-        displayName: Sysdig
+      - displayName: Sysdig
         path: sysdig
       statusDescriptors:
       - description: The status of the Sysdig Agent
         displayName: Sysdig Agent status
         path: conditions
+      version: v1
   description: |-
     [Sysdig](https://www.sysdig.com/) is a unified platform for container and
     microservices monitoring, troubleshooting, security and forensics. Sysdig
@@ -167,11 +165,11 @@ spec:
       clusterPermissions:
       - rules:
         - apiGroups:
-          - "*"
+          - '*'
           resources:
-          - "*"
+          - '*'
           verbs:
-          - "*"
+          - '*'
         - apiGroups:
           - authentication.k8s.io
           resources:
@@ -204,7 +202,7 @@ spec:
                 - --metrics-bind-address=127.0.0.1:8080
                 - --leader-elect
                 - --leader-election-id=sysdig-operator
-                image: registry.connect.redhat.com/sysdig/sysdig-operator@sha256:d6ec93eb0e8a3a13f7a7ac03d362734996c06819f43811383a11c00cab3a0876
+                image: registry.connect.redhat.com/sysdig/sysdig-operator:1.12.40
                 livenessProbe:
                   httpGet:
                     path: /healthz

--- a/bundle/manifests/sysdig.com_sysdigagents.yaml
+++ b/bundle/manifests/sysdig.com_sysdigagents.yaml
@@ -31,10 +31,8 @@ spec:
             type: object
           spec:
             description: Spec defines the desired state of SysdigAgent
-            type: object
             properties:
               sysdig:
-                type: object
                 properties:
                   accessKey:
                     type: string
@@ -45,17 +43,19 @@ spec:
                   settings:
                     type: object
                     x-kubernetes-preserve-unknown-fields: true
+                type: object
                 x-kubernetes-preserve-unknown-fields: true
               tolerations:
-                type: array
                 items:
-                  type: object
                   properties:
                     effect:
                       type: string
                     key:
                       type: string
+                  type: object
                   x-kubernetes-preserve-unknown-fields: true
+                type: array
+            type: object
             x-kubernetes-preserve-unknown-fields: true
           status:
             description: Status defines the observed state of SysdigAgent

--- a/config/crd/bases/sysdig.com_sysdigagents.yaml
+++ b/config/crd/bases/sysdig.com_sysdigagents.yaml
@@ -32,6 +32,30 @@ spec:
           spec:
             description: Spec defines the desired state of SysdigAgent
             type: object
+            properties:
+              sysdig:
+                type: object
+                properties:
+                  accessKey:
+                    type: string
+                  disableCaptures:
+                    type: boolean
+                  existingAccessKeySecret:
+                    type: string
+                  settings:
+                    type: object
+                    x-kubernetes-preserve-unknown-fields: true
+                x-kubernetes-preserve-unknown-fields: true
+              tolerations:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    effect:
+                      type: string
+                    key:
+                      type: string
+                  x-kubernetes-preserve-unknown-fields: true
             x-kubernetes-preserve-unknown-fields: true
           status:
             description: Status defines the observed state of SysdigAgent

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -12,5 +12,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
 - name: controller
-  newName: scan.connect.redhat.com/ospid-2953a149-0b38-4515-9768-dd548c234edb/sysdig-operator
+  newName: registry.connect.redhat.com/sysdig/sysdig-operator
   newTag: 1.12.40

--- a/config/manifests/bases/sysdig-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/sysdig-operator.clusterserviceversion.yaml
@@ -3,27 +3,146 @@ kind: ClusterServiceVersion
 metadata:
   annotations:
     alm-examples: '[]'
-    capabilities: Basic Install
+    capabilities: Seamless Upgrades
+    categories: Security, Monitoring
+    certified: "true"
+    containerImage: registry.connect.redhat.com/sysdig/sysdig-operator@sha256:d6ec93eb0e8a3a13f7a7ac03d362734996c06819f43811383a11c00cab3a0876
+    description: |
+      Sysdig is a unified platform for container and microservices monitoring, troubleshooting, security and forensics. Sysdig platform has been built on top of Sysdig tool and Sysdig Inspect open-source technologies.
+    repository: https://github.com/sysdiglabs/sysdig-operator
+    support: Sysdig, Inc.
   name: sysdig-operator.v0.0.0
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
-  customresourcedefinitions: {}
-  description: Sysdig is a unified platform for container and microservices monitoring,
-    troubleshooting, security and forensics. Sysdig platform has been built on top
-    of Sysdig tool and Sysdig Inspect open-source technologies.
+  customresourcedefinitions:
+    owned:
+    - kind: SysdigAgent
+      name: sysdigagents.sysdig.com
+      resources:
+      - kind: Service
+        name: ""
+        version: v1
+      - kind: DaemonSet
+        name: ""
+        version: v1
+      specDescriptors:
+      - displayName: Tolerations
+        path: tolerations
+      - displayName: Sysdig
+        path: sysdig
+      statusDescriptors:
+      - description: The status of the Sysdig Agent
+        displayName: Sysdig Agent status
+        path: conditions
+      version: v1
+  description: |-
+    [Sysdig](https://www.sysdig.com/) is a unified platform for container and
+    microservices monitoring, troubleshooting, security and forensics. Sysdig
+    platform has been built on top of
+    [Sysdig tool](https://sysdig.com/opensource/sysdig/) and
+    [Sysdig Inspect](https://sysdig.com/blog/sysdig-inspect/) open-source
+    technologies.
+    This operator installs the Sysdig Agent for
+    [Sysdig Monitor](https://sysdig.com/product/monitor/) and
+    [Sysdig Secure](https://sysdig.com/product/secure/) to all nodes in your
+    cluster via a DaemonSet.
+    ## Settings
+    This operator, uses the same options than the
+    [Helm Chart](https://hub.helm.sh/charts/stable/sysdig), please take a look
+    to all the options in the following table:
+    | Parameter                         | Description                                                            | Default                                     |
+    | ---                               | ---                                                                    | ---                                         |
+    | `image.registry`                  | Sysdig agent image registry                                            | `docker.io`                                 |
+    | `image.repository`                | The image repository to pull from                                      | `sysdig/agent`                              |
+    | `image.tag`                       | The image tag to pull                                                  | `REPLACE_AGENT_VERSION`                                     |
+    | `image.pullPolicy`                | The Image pull policy                                                  | `IfNotPresent`                              |
+    | `image.pullSecrets`               | Image pull secrets                                                     | `nil`                                       |
+    | `resources.requests.cpu`          | CPU requested for being run in a node                                  | `600m`                                      |
+    | `resources.requests.memory`       | Memory requested for being run in a node                               | `512Mi`                                     |
+    | `resources.limits.cpu`            | CPU limit                                                              | `2000m`                                     |
+    | `resources.limits.memory`         | Memory limit                                                           | `1536Mi`                                    |
+    | `rbac.create`                     | If true, create & use RBAC resources                                   | `true`                                      |
+    | `serviceAccount.create`           | Create serviceAccount                                                  | `true`                                      |
+    | `serviceAccount.name`             | Use this value as serviceAccountName                                   | ` `                                         |
+    | `daemonset.updateStrategy.type`   | The updateStrategy for updating the daemonset                          | `RollingUpdate`                             |
+    | `daemonset.affinity`              | Node affinities                                                        | `nil`                                       |
+    | `daemonset.annotations`           | Custom annotations for daemonset                                       | `{}`                                        |
+    | `slim.enabled`                    | Use the slim based Sysdig Agent image                                  | `false`                                     |
+    | `slim.kmoduleImage.repository`    | The kernel module image builder repository to pull from                | `sysdig/agent-kmodule`                      |
+    | `slim.resources.requests.cpu`     | CPU requested for building the kernel module                           | `1000m`                                     |
+    | `slim.resources.requests.memory`  | Memory requested for building the kernel module                        | `348Mi`                                     |
+    | `slim.resources.limits.memory`    | Memory limit for building the kernel module                            | `512Mi`                                     |
+    | `ebpf.enabled`                    | Enable eBPF support for Sysdig instead of `sysdig-probe` kernel module | `false`                                     |
+    | `ebpf.settings.mountEtcVolume`    | Needed to detect which kernel version are running in Google COS        | `true`                                      |
+    | `sysdig.accessKey`                | Your Sysdig Monitor Access Key                                         | `Nil` You must provide your own key         |
+    | `sysdig.settings`                 | Settings for agent's configuration file                                | ` `                                         |
+    | `secure.enabled`                  | Enable Sysdig Secure                                                   | `true`                                      |
+    | `auditLog.enabled`                | Enable K8s audit log support for Sysdig Secure                         | `false`                                     |
+    | `auditLog.auditServerUrl`         | The URL where Sysdig Agent listens for K8s audit log events            | `0.0.0.0`                                   |
+    | `auditLog.auditServerPort`        | Port where Sysdig Agent listens for K8s audit log events               | `7765`                                      |
+    | `auditLog.dynamicBackend.enabled` | Deploy the Audit Sink where Sysdig listens for K8s audit log events    | `false`                                     |
+    | `customAppChecks`                 | The custom app checks deployed with your agent                         | `{}`                                        |
+    | `tolerations`                     | The tolerations for scheduling                                         | `node-role.kubernetes.io/master:NoSchedule` |
+    | `scc.create`                      | Create OpenShift's Security Context Constraint                         | `false`                                     |
+    For example, if you want to deploy a DaemonSet with eBPF and with Sysdig Secure
+    enabled:
+    ```yaml
+    apiVersion: sysdig.com/v1
+    kind: SysdigAgent
+    metadata:
+      name: agent-with-ebpf-and-secure
+    spec:
+      ebpf:
+        enabled: true
+      daemonset:
+        annotations:
+          productID: SysdigSecureDevopsPlatform
+          productName: Sysdig Secure DevOps Platform
+          productVersion: REPLACE_VERSION
+      scc:
+        create: true
+      sysdig:
+        accessKey: XXX
+    ```
+    Please, notice that `sysdig.accessKey` is **mandatory**. Once you have provided
+    the accessKey, you can apply this file with `kubectl apply -f`
+    ## Getting your Access Key
+    To retrieve the key and use it in the agent:
+    1. Log in to Sysdig Monitor or Sysdig Secure (maybe as administrator) and
+       select **Settings**.
+    2. Choose Agent Installation.
+    3. Use the Copy button to copy the access key at the top of the page.
+    If you need more help, you can read more about this process in the [Agent Installation: Overview and Key](
+    https://sysdigdocs.atlassian.net/wiki/spaces/Platform/pages/213352719/Agent+Installation+Overview+and+Key)
+    documentation page.
+    ## Verify Metrics in Sysdig Monitor UI
+    Once you have deployed the Sysdig Agent, it's time to verify that everything is
+    working as expected. So, we are going to log in Sysdig Monitor to do the check.
+    1. Access Sysdig Monitor:
+       **SaaS**: https://app.sysdigcloud.com
+       Log in with your Sysdig user name and password.
+    2. Select the **Explore** tab to see if metrics are displayed.
+    3. To verify that kube state metrics and cluster name are working correctly:
+       Select the **Explore tab** and create a grouping by `kubernetes.cluster.name` and `kubernetes.pod.name`.
+    4. Select an individual container or pod to see details.
+    Don't rush about getting Kubernetes metadata. Pods, deployments ... appear a
+    minute or two later than the nodes/containers themselves; if pod names do not
+    appear immediately, wait and retry the Explore view.
+    You can read more about verification in the [Verify Metrics in Sysdig Monitor UI section](https://sysdigdocs.atlassian.net/wiki/spaces/Platform/pages/256475257/GKE+Installation+Steps#GKEInstallationSteps-VerifyMetricsinSysdigMonitorUI)
+    in the documentation pages.
   displayName: Sysdig Agent Operator
   icon:
-  - base64data: ""
-    mediatype: ""
+  - base64data: PHN2ZyBpZD0iTGF5ZXJfMSIgZGF0YS1uYW1lPSJMYXllciAxIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHhtbG5zOnhsaW5rPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5L3hsaW5rIiB2aWV3Qm94PSIwIDAgMjE3IDIwOCI+PGRlZnM+PHN0eWxlPi5jbHMtMSwuY2xzLTQsLmNscy01e2ZpbGw6bm9uZTt9LmNscy0ye2ZpbGw6I2ZmZjt9LmNscy0ze2ZpbGw6IzAwYjRjODt9LmNscy00LC5jbHMtNXtzdHJva2U6IzBlMGYyNjtzdHJva2UtbWl0ZXJsaW1pdDoxMDt9LmNscy00e3N0cm9rZS13aWR0aDo1cHg7fS5jbHMtNXtzdHJva2Utd2lkdGg6MS41OHB4O30uY2xzLTZ7Y2xpcC1wYXRoOnVybCgjY2xpcC1wYXRoKTt9PC9zdHlsZT48Y2xpcFBhdGggaWQ9ImNsaXAtcGF0aCI+PHBhdGggY2xhc3M9ImNscy0xIiBkPSJNMTY5LjUyLDE2My4yNWwtMTEuNTgsMTEuNTktMzQtMzQsMy40Ny0zLjQ5LTE3Ljc3LTE3Ljc3TDg2Ljg1LDE0Mi40LDU4LjMzLDExMy44OGMtMjgtMjgtMTEuNjYtNzMuNDctMTEuNjYtNzMuNDdaIi8+PC9jbGlwUGF0aD48L2RlZnM+PHRpdGxlPkFydGJvYXJkIDE8L3RpdGxlPjxwb2x5Z29uIGNsYXNzPSJjbHMtMiIgcG9pbnRzPSIxNDYuODkgMTE4LjkgMTIzLjk1IDE0MC44NSAxNTcuOTQgMTc0Ljg0IDE4MS4xIDE1MS42NyAxNDYuODkgMTE4LjkiLz48cGF0aCBjbGFzcz0iY2xzLTIiIGQ9Ik0xNDMuNjIsMTIxLjE2bC0xNy43Ny0xNy43NywyMi44Mi0yMi44MUwxMjAuMTUsNTIuMDZjLTI4LTI4LTczLjQ4LTExLjY1LTczLjQ4LTExLjY1UzMwLjMzLDg1Ljg5LDU4LjMzLDExMy44OEw4Ni44NSwxNDIuNGwyMi44LTIyLjgxLDE3Ljc3LDE3Ljc3WiIvPjxwYXRoIGNsYXNzPSJjbHMtMiIgZD0iTTY0LjMsNThjLTEuODgsMTEuMy0yLjQ2LDI5LjE4LDkuMTIsNDAuNzZsMTMuNDMsMTMuNDMiLz48cGF0aCBjbGFzcz0iY2xzLTMiIGQ9Ik0xNjkuNTIsMTYzLjI1bC0xMS41OCwxMS41OS0zNC0zNCwzLjQ3LTMuNDktMTcuNzctMTcuNzdMODYuODUsMTQyLjQsNTguMzMsMTEzLjg4Yy0yOC0yOC0xMS42Ni03My40Ny0xMS42Ni03My40N1oiLz48cGF0aCBjbGFzcz0iY2xzLTQiIGQ9Ik0xNDMuNjIsMTIxLjE2bC0xNy43Ny0xNy43NywyMi44Mi0yMi44MUwxMjAuMTUsNTIuMDZjLTI4LTI4LTczLjQ4LTExLjY1LTczLjQ4LTExLjY1UzMwLjMzLDg1Ljg5LDU4LjMzLDExMy44OEw4Ni44NSwxNDIuNGwyMi44LTIyLjgxLDE3Ljc3LDE3Ljc3WiIvPjxyZWN0IGNsYXNzPSJjbHMtNSIgeD0iMTM2LjE0IiB5PSIxMjIuMjMiIHdpZHRoPSIzMi43NiIgaGVpZ2h0PSI0OC4wNiIgdHJhbnNmb3JtPSJ0cmFuc2xhdGUoMzYzLjggMTQxLjgzKSByb3RhdGUoMTM1KSIvPjxyZWN0IGNsYXNzPSJjbHMtNCIgeD0iMTM2LjE0IiB5PSIxMjIuMjMiIHdpZHRoPSIzMi43NiIgaGVpZ2h0PSI0OC4wNiIgdHJhbnNmb3JtPSJ0cmFuc2xhdGUoMzYzLjggMTQxLjgzKSByb3RhdGUoMTM1KSIvPjxnIGNsYXNzPSJjbHMtNiI+PHBhdGggY2xhc3M9ImNscy00IiBkPSJNNzIuNzQsMzcuODQsNjcuNjMsNTAuMDVhNTMuNTksNTMuNTksMCwwLDAtNCwyNi40MmMuODYsNy45MywzLjU3LDE2LDkuODQsMjIuMzJsMTMuNDMsMTMuNDMiLz48L2c+PC9zdmc+
+    mediatype: image/svg+xml
   install:
     spec:
       deployments: null
     strategy: ""
   installModes:
-  - supported: false
+  - supported: true
     type: OwnNamespace
-  - supported: false
+  - supported: true
     type: SingleNamespace
   - supported: false
     type: MultiNamespace
@@ -38,9 +157,19 @@ spec:
   - run-time
   - syscall
   links:
+  - name: Sysdig
+    url: https://sysdig.com
+  - name: Documentation
+    url: https://sysdigdocs.atlassian.net/wiki/spaces/Platform/overview
+  - name: Helm Chart
+    url: https://hub.helm.sh/charts/stable/sysdig
   - name: Sysdig Operator
-    url: https://sysdig-operator.domain
+    url: https://github.com/sysdiglabs/sysdig-operator
+  - name: Configuration Options
+    url: https://github.com/helm/charts/tree/master/stable/sysdig#configuration
   maintainers:
+  - email: nestor.salceda@sysdig.com
+    name: Néstor Salceda
   - email: ashwin.chandrasekar@sysdig.com
     name: Ashwin Chandrasekar
   maturity: alpha

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -3,81 +3,10 @@ kind: ClusterRole
 metadata:
   name: manager-role
 rules:
-##
-## Base operator rules
-##
-# We need to get namespaces so the operator can read namespaces to ensure they exist
 - apiGroups:
-  - ""
+  - "*"
   resources:
-  - namespaces
-  verbs:
-  - get
-# We need to manage Helm release secrets
-- apiGroups:
-  - ""
-  resources:
-  - secrets
+  - "*"
   verbs:
   - "*"
-# We need to create events on CRs about things happening during reconciliation
-- apiGroups:
-  - ""
-  resources:
-  - events
-  verbs:
-  - create
-
-##
-## Rules for sysdig.com/v1, Kind: SysdigAgent
-##
-- apiGroups:
-  - sysdig.com
-  resources:
-  - sysdigagents
-  - sysdigagents/status
-  - sysdigagents/finalizers
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - ""
-  resources:
-  - pods
-  - services
-  - services/finalizers
-  - endpoints
-  - persistentvolumeclaims
-  - events
-  - configmaps
-  - secrets
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - apps
-  resources:
-  - deployments
-  - daemonsets
-  - replicasets
-  - statefulsets
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
-
 #+kubebuilder:scaffold:rules

--- a/config/samples/kustomization.yaml
+++ b/config/samples/kustomization.yaml
@@ -1,4 +1,4 @@
 ## Append samples you want in your CSV to this file as resources ##
 resources:
-- sysdig_v1_sysdigagent.yaml
+- sysdig_v1_sysdigagent_minimal.yaml
 #+kubebuilder:scaffold:manifestskustomizesamples

--- a/config/samples/sysdig_v1_sysdigagent_minimal.yaml
+++ b/config/samples/sysdig_v1_sysdigagent_minimal.yaml
@@ -1,0 +1,13 @@
+apiVersion: sysdig.com/v1
+kind: SysdigAgent
+metadata:
+  name: sysdigagent-sample
+spec:
+  sysdig:
+    accessKey: "REPLACE ME"
+    disableCaptures: false
+    existingAccessKeySecret: ""
+    settings: {}
+  tolerations:
+  - effect: NoSchedule
+    key: node-role.kubernetes.io/master


### PR DESCRIPTION
Update the config resources so that `make bundle` will resemble a valid bundle as closely as possible. This is part of some clean up before introducing CI