### PR TITLE
Use submodule to update chart to 1.12.43

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "charts"]
+	path = charts
+	url = https://github.com/sysdiglabs/charts

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,5 +10,5 @@ COPY LICENSE /licenses/
 
 ENV HOME=/opt/helm
 COPY watches.yaml ${HOME}/watches.yaml
-COPY helm-charts  ${HOME}/helm-charts
+COPY charts/charts/sysdig  ${HOME}/helm-charts/sysdig
 WORKDIR ${HOME}

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 # To re-generate a bundle for another specific version without changing the standard setup, you can:
 # - use the VERSION as arg of the bundle target (e.g make bundle VERSION=0.0.2)
 # - use environment variables to overwrite this value (e.g export VERSION=0.0.2)
-VERSION ?= 1.12.40
+VERSION ?= 1.12.43
 
 # CHANNELS define the bundle channels used in the bundle.
 # Add a new line here if you would like to change its default config. (E.g CHANNELS = "candidate,fast,stable")

--- a/README.md
+++ b/README.md
@@ -15,6 +15,18 @@ spec:
   <Helm values>
 ```
 
+# Updates
+
+There are two parts that can be updated: the operator image and the bundle. Ideally, these two parts would be in sync.
+
+To manually perform a chart update:
+```
+cd charts
+git checkout tags/sysdig-<version>
+```
+
+and commit changes. Update the `VERSION` in the Makefile to the checked out chart version, and build the operator and bundle.
+
 # Building
 
 ## Operator

--- a/bundle/manifests/sysdig-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/sysdig-operator.clusterserviceversion.yaml
@@ -36,7 +36,7 @@ metadata:
     operators.operatorframework.io/project_layout: helm.sdk.operatorframework.io/v1
     repository: https://github.com/sysdiglabs/sysdig-operator
     support: Sysdig, Inc.
-  name: sysdig-operator.v1.12.40
+  name: sysdig-operator.v1.12.43
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -337,7 +337,7 @@ spec:
                 - --metrics-bind-address=127.0.0.1:8080
                 - --leader-elect
                 - --leader-election-id=sysdig-operator
-                image: registry.connect.redhat.com/sysdig/sysdig-operator:1.12.40
+                image: registry.connect.redhat.com/sysdig/sysdig-operator:1.12.43
                 livenessProbe:
                   httpGet:
                     path: /healthz
@@ -436,4 +436,4 @@ spec:
   provider:
     name: Sysdig
     url: https://sysdig.com
-  version: 1.12.40
+  version: 1.12.43

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -13,4 +13,4 @@ kind: Kustomization
 images:
 - name: controller
   newName: registry.connect.redhat.com/sysdig/sysdig-operator
-  newTag: 1.12.40
+  newTag: 1.12.43


### PR DESCRIPTION
This adds the charts repo as a submodule, currently checked out at `tags/sysdig-1.12.43`, and updates the Dockerfile to use this new path.