### PR TITLE
Add workflows for updating and building the operator

### DIFF
--- a/.github/workflows/build-docker.yaml
+++ b/.github/workflows/build-docker.yaml
@@ -1,0 +1,49 @@
+name: Docker Build and Push
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+          submodules: true
+      # - name: Login to Artifactory
+      #   uses: docker/login-action@v1
+      #   with:
+      #     registry: docker.internal.sysdig.com
+      #     username: ${{ secrets.ARTIFACTORY_USERNAME }}
+      #     password: ${{ secrets.ARTIFACTORY_PASSWORD }}
+      - name: Login to Red Hat Connect Scanning
+        uses: docker/login-action@v1
+        with:
+          registry: scan.connect.redhat.com
+          username: ${{ secrets.REDHAT_SCAN_CONNECT_USERNAME }}
+          password: ${{ secrets.REDHAT_SCAN_CONNECT_PASSWORD }}
+      - name: Build operator image
+        id: build_image
+        run: |
+          set -ex
+
+          make docker-build
+
+          BUILT_IMAGE=$(docker images registry.connect.redhat.com/sysdig/sysdig-operator --format "{{.Repository}}:{{.Tag}}" | head -n 1)
+          echo "::set-output name=built_image::${BUILT_IMAGE}"
+
+          BUILT_IMAGE_TAG=$(docker images registry.connect.redhat.com/sysdig/sysdig-operator --format "{{.Tag}}" | head -n 1)
+          echo "::set-output name=built_image_tag::${BUILT_IMAGE_TAG}"
+      - name: Push images
+        uses: akhilerm/tag-push-action@v2.0.0
+        with:
+          src: ${{ steps.build_image.outputs.built_image }}
+          dst: |
+            scan.connect.redhat.com/ospid-2953a149-0b38-4515-9768-dd548c234edb/sysdig-operator:${{ steps.build_image.outputs.built_image_tag }}
+      #       docker.internal.sysdig.com/utils/sysdig-operator:${{ steps.build_iamges.outputs.built_image_tag }}
+

--- a/.github/workflows/build-docker.yaml
+++ b/.github/workflows/build-docker.yaml
@@ -27,23 +27,28 @@ jobs:
           registry: scan.connect.redhat.com
           username: ${{ secrets.REDHAT_SCAN_CONNECT_USERNAME }}
           password: ${{ secrets.REDHAT_SCAN_CONNECT_PASSWORD }}
-      - name: Build operator image
-        id: build_image
+      - name: Get build version
+        id: build_version
         run: |
           set -ex
-
-          make docker-build
-
-          BUILT_IMAGE=$(docker images registry.connect.redhat.com/sysdig/sysdig-operator --format "{{.Repository}}:{{.Tag}}" | head -n 1)
-          echo "::set-output name=built_image::${BUILT_IMAGE}"
-
-          BUILT_IMAGE_TAG=$(docker images registry.connect.redhat.com/sysdig/sysdig-operator --format "{{.Tag}}" | head -n 1)
-          echo "::set-output name=built_image_tag::${BUILT_IMAGE_TAG}"
-      - name: Push images
-        uses: akhilerm/tag-push-action@v2.0.0
+          BUILD_VERSION=$(grep -oP 'VERSION \?= \K[0-9]+\.[0-9]+\.[0-9]+' Makefile)
+          echo "::set-output name=build_version::${BUILD_VERSION}"
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
         with:
-          src: ${{ steps.build_image.outputs.built_image }}
-          dst: |
-            scan.connect.redhat.com/ospid-2953a149-0b38-4515-9768-dd548c234edb/sysdig-operator:${{ steps.build_image.outputs.built_image_tag }}
-      #       docker.internal.sysdig.com/utils/sysdig-operator:${{ steps.build_iamges.outputs.built_image_tag }}
-
+          images: |
+            scan.connect.redhat.com/ospid-2953a149-0b38-4515-9768-dd548c234edb/sysdig-operator
+          tags: |
+            ${{ steps.build_version.outputs.build_version }}
+      - name: Print meta
+        run: |
+          echo "Tags: ${{ steps.meta.outputs.tags }}"
+          echo "labels: ${{ steps.meta.outputs.labels }}"
+      - name: Build and push Docker images
+        uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/update-subchart.yaml
+++ b/.github/workflows/update-subchart.yaml
@@ -1,0 +1,61 @@
+name: Update subchart
+
+on:
+  repository_dispatch:
+    types: [ sysdig-release ]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'The chart submodule will be updated to this tag'
+
+jobs:
+  update-submodule:
+    runs-on: ubuntu-latest
+
+    env:
+      WORKFLOW_DISPATCH_TAG: sysdig-1.12.47
+      REPOSITORY_DISPATCH_TAG: ${{ github.event.client_payload.tag }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+          submodules: true
+      - name: Set tag
+        id: set_tag
+        run: |
+          set -ex
+
+          CHART_TAG=''
+          if [[ ! -z "$REPOSITORY_DISPATCH_TAG" ]]; then
+            echo "::set-output name=chart_tag::${REPOSITORY_DISPATCH_TAG}"
+            CHART_TAG="$REPOSITORY_DISPATCH_TAG"
+          elif [[ ! -z "$WORKFLOW_DISPATCH_TAG" ]]; then
+            echo "::set-output name=chart_tag::${WORKFLOW_DISPATCH_TAG}"
+            CHART_TAG="$WORKFLOW_DISPATCH_TAG"
+          fi
+
+          if [[ ! -z "$CHART_TAG" ]]; then
+            echo "${CHART_TAG} will be checked out!"
+            exit 0
+          else
+            echo "No tag found!"
+            exit 1
+          fi
+      - name: Checkout submodule
+        env:
+          CHART_TAG: ${{ steps.set_tag.outputs.chart_tag }}
+        working-directory: ./charts
+        run: |
+          git checkout $CHART_TAG
+      - name: Update VERSION in Makefile
+        env:
+          CHART_TAG: ${{ steps.set_tag.outputs.chart_tag }}
+        run: |
+          CHART_VERSION=$(echo "${CHART_TAG}" | grep -Eo '[0-9]+\.[0-9]+\.[0-9]+')
+          sed -i 's/VERSION\s*?=.*/VERSION ?= '${CHART_VERSION}'/' Makefile
+      - name: Commit back to repo
+        uses: stefanzweifel/git-auto-commit-action@v4
+        with:
+          commit_message: Update charts submodule to ${{ steps.set_tag.outputs.chart_tag }}


### PR DESCRIPTION
Adds two workflows:
- update the `charts` submodule to a given tag. Also updates the Makefile VERSION to match. Allows manual or repository dispatch, so there will need to be a matching job in the charts repo to do a [repository dispatch](https://github.com/peter-evans/repository-dispatch) when we release the sysdig chart. For now, it will just be manual.
- the second workflow is a pretty straightforward one to build and push the operator images to multiple repositories